### PR TITLE
Add icons in addition to color to indicate valid/invalid spaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,84 @@ const Game: Component<{ state: GameState }> = (props) => {
 
   return (
     <svg class="w-full h-full" viewBox={viewBox()}>
+      <defs>
+        <pattern id="pattern-valid-dark" x="0" y="0" width="1" height="1">
+          <rect
+            x="0"
+            y="0"
+            width={squareWidth}
+            height={squareWidth}
+            fill="green"
+          />
+          <text
+            font-size={squareWidth / 4 + 'px'}
+            x="0"
+            y="0"
+            stroke="white"
+            dx={squareWidth * 0.675}
+            dy={squareWidth * 0.25}
+          >
+            ✓
+          </text>
+        </pattern>
+        <pattern id="pattern-valid-light" x="0" y="0" width="1" height="1">
+          <rect
+            x="0"
+            y="0"
+            width={squareWidth}
+            height={squareWidth}
+            fill="rgba(0, 255, 0, 0.3)"
+          />
+          <text
+            font-size={squareWidth / 4 + 'px'}
+            x="0"
+            y="0"
+            stroke="black"
+            dx={squareWidth * 0.675}
+            dy={squareWidth * 0.25}
+          >
+            ✓
+          </text>
+        </pattern>
+        <pattern id="pattern-invalid-dark" x="0" y="0" width="1" height="1">
+          <rect
+            x="0"
+            y="0"
+            width={squareWidth}
+            height={squareWidth}
+            fill="red"
+          />
+          <text
+            font-size={squareWidth / 4 + 'px'}
+            x="0"
+            y="0"
+            stroke="white"
+            dx={squareWidth * 0.675}
+            dy={squareWidth * 0.25}
+          >
+            ╳
+          </text>
+        </pattern>
+        <pattern id="pattern-invalid-light" x="0" y="0" width="1" height="1">
+          <rect
+            x="0"
+            y="0"
+            width={squareWidth}
+            height={squareWidth}
+            fill="rgba(255, 0, 0, 0.3)"
+          />
+          <text
+            font-size={squareWidth / 4 + 'px'}
+            x="0"
+            y="0"
+            stroke="black"
+            dx={squareWidth * 0.675}
+            dy={squareWidth * 0.25}
+          >
+            ╳
+          </text>
+        </pattern>
+      </defs>
       <For each={props.state.squaresArray()}>
         {(point, i) => (
           <GameSquare state={props.state} point={point} width={squareWidth} />

--- a/src/GameSquare.tsx
+++ b/src/GameSquare.tsx
@@ -30,11 +30,17 @@ export const GameSquare: Component<{
 
   const isHighlighted = () => isPieceMoving() || isPossibleMove();
 
-  const highlightColor = () => isYourPiece() ? "green" : "red";
-  
-  const opacity = () => ((point.x + point.y) % 2 === 1 ? 1 : 0.3);
+  const isDark = () => (point.x + point.y) % 2 === 1;
 
-  const fill = () => (isHighlighted() ? highlightColor() : "gray");
+  const highlightColor = () =>
+    `url(#pattern-${isYourPiece() ? 'valid' : 'invalid'}-${
+      isDark() ? 'dark' : 'light'
+    })`;
+
+  const fill = () =>
+    isHighlighted()
+      ? highlightColor()
+      : `${isDark() ? 'gray' : 'rgba(128, 128, 128, 0.3)'}`;
 
   function clicked() {
     if (isPossibleMove()) {
@@ -47,7 +53,6 @@ export const GameSquare: Component<{
     <rect
       onClick={clicked}
       fill={fill()}
-      fill-opacity={opacity()}
       width={props.width}
       height={props.width}
       x={point.x * props.width}


### PR DESCRIPTION
Related to #2.

Here's some screenshots at my (poor) attempt at adding icons to help indicate validity of moves/spaces, using SVG pattern defs as fills instead of just colors and opacity.

It's just using an additional rect and text in the pattern as the background/fill. I'm not sure why the text is so bold, it makes it a little hard to distinguish the icons, but I'm sure there's a way to fix that. Or, could use O and X or something instead, for more control.

Bear, valid, color, with icons:
![icons-bear-valid-color](https://user-images.githubusercontent.com/8390324/182303098-17be6b8f-cd98-46f7-b05b-b653ecbfaf7f.png)

Bear, valid, greyscale, with icons:
![icons-bear-valid-greyscale](https://user-images.githubusercontent.com/8390324/182303108-ec4d3dcb-cac7-4a8f-b5b1-291b6f7b47d9.png)

King, invalid, color, with icons:
![icons-king-invalid-color](https://user-images.githubusercontent.com/8390324/182303106-4d68705c-4186-4cae-b43f-cb6b80ee463d.png)

King, invalid, greyscale, with icons:
![icons-king-invalid-greyscale](https://user-images.githubusercontent.com/8390324/182303110-8137007e-d0b5-4ce9-9a6c-051265664bc4.png)